### PR TITLE
Update semver version of itertools dependency

### DIFF
--- a/ouroboros_macro/Cargo.toml
+++ b/ouroboros_macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 heck = "0.4.1"
-itertools = "0.11.0"
+itertools = "0.12.0"
 proc-macro2 = "1.0"
 proc-macro-error = "1.0.4"
 quote = "1.0"


### PR DESCRIPTION
Ouroboros_macro  is the only crate in my dependency tree that depends on the old version of itertools, making me pull in both versions.

This PR updates the dependency on itertools to the latest semver version. No code changes were needed to make tests pass (so it doesn't seem the breaking change actually affected the use of itertools in ouroboros).

Please also make a new release soon with this in it so I can actually make use of the reduced code bloat and reduced compile time in my project.