### PR TITLE
Remove dependency on the `itertools` crate

### DIFF
--- a/ouroboros_macro/Cargo.toml
+++ b/ouroboros_macro/Cargo.toml
@@ -13,7 +13,6 @@ proc-macro = true
 
 [dependencies]
 heck = "0.4.1"
-itertools = "0.12.0"
 proc-macro2 = "1.0"
 proc-macro2-diagnostics = "0.10"
 quote = "1.0"

--- a/ouroboros_macro/src/generate/with_mut.rs
+++ b/ouroboros_macro/src/generate/with_mut.rs
@@ -2,7 +2,6 @@ use crate::{
     info_structures::{FieldType, Options, StructInfo},
     utils::{replace_this_with_lifetime, uses_this_lifetime},
 };
-use itertools::Itertools;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Error, Lifetime, WhereClause};
@@ -24,7 +23,7 @@ pub fn make_with_all_mut_function(
         let field_name = &field.name;
         let field_type = &field.typ;
         let lifetime = format_ident!("this{}", lifetime_idents.len());
-        if uses_this_lifetime(quote! { #field_type }) || field.field_type == FieldType::Borrowed  {
+        if uses_this_lifetime(quote! { #field_type }) || field.field_type == FieldType::Borrowed {
             lifetime_idents.push(lifetime.clone());
         }
         let field_type = replace_this_with_lifetime(quote! { #field_type }, lifetime.clone());
@@ -87,9 +86,9 @@ pub fn make_with_all_mut_function(
             .predicates
             .extend(extra.predicates.into_iter());
     }
-    for (outlives, lt) in lifetime_idents.iter().tuple_windows() {
-        let lt = Lifetime::new(&format!("'{}", lt), Span::call_site());
-        let outlives = Lifetime::new(&format!("'{}", outlives), Span::call_site());
+    for idents in lifetime_idents.windows(2) {
+        let lt = Lifetime::new(&format!("'{}", idents[1]), Span::call_site());
+        let outlives = Lifetime::new(&format!("'{}", idents[0]), Span::call_site());
         let extra: WhereClause = syn::parse_quote! { where #lt: #outlives };
         generic_where
             .predicates

--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -22,7 +22,6 @@ use generate::{
 };
 use heck::ToSnakeCase;
 use info_structures::BuilderType;
-use itertools::Itertools;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2::TokenTree;
@@ -65,7 +64,7 @@ fn self_referencing_impl(
     let with_errors = with_errors
         .into_iter()
         .map(|err| err.emit_as_expr_tokens())
-        .collect_vec();
+        .collect::<Vec<_>>();
     let (with_all_struct_def, with_all_fn_def) = make_with_all_function(&info, options)?;
     let (with_all_mut_struct_def, with_all_mut_fn_def) =
         make_with_all_mut_function(&info, options)?;


### PR DESCRIPTION
This crate was only used in two small places in the ouroboros_macro crate which could be easily replaced with stdlib variants.

Removing it might help compile times a bit.

Found this rather randomly as I wondered why itertools shows up in my depedency tree, saw the macro crate uses it and replaced it as I saw the few places where it's used are trivial.
