### PR TITLE
Change lifetime bounds to allow copying references

### DIFF
--- a/examples/src/fail_tests/move_ref_not_borrowed.rs
+++ b/examples/src/fail_tests/move_ref_not_borrowed.rs
@@ -1,0 +1,29 @@
+use ouroboros::self_referencing;
+
+#[self_referencing]
+struct CopyRef {
+    data: String,
+    #[borrows(data)]
+    #[covariant]
+    ref1: Option<&'this str>,
+    other: String,
+    #[borrows(other)]
+    #[covariant]
+    ref2: Option<&'this str>,
+}
+
+fn main() {
+    let mut s = CopyRefBuilder {
+        data: "test".to_string(),
+        ref1_builder: |_| None,
+        other: "other".to_string(),
+        ref2_builder: |_| None,
+    }
+    .build();
+
+    s.with_mut(|f| {
+        *f.ref1 = Some(f.other);
+    });
+
+    drop(s);
+}

--- a/examples/src/fail_tests/move_ref_not_borrowed.stderr
+++ b/examples/src/fail_tests/move_ref_not_borrowed.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `s` does not live long enough
-  --> src/fail_tests/move_ref_out_of_bound.rs:24:5
+  --> src/fail_tests/move_ref_not_borrowed.rs:24:5
    |
 16 |       let mut s = CopyRefBuilder {
    |           ----- binding `s` declared here
@@ -8,16 +8,15 @@ error[E0597]: `s` does not live long enough
    |       ^ borrowed value does not live long enough
    |  _____|
    | |
-25 | |         *f.ref2 = Some(f.other);
-26 | |         *f.ref1 = *f.ref2;
-27 | |     });
+25 | |         *f.ref1 = Some(f.other);
+26 | |     });
    | |______- argument requires that `s` is borrowed for `'static`
 ...
-30 |   }
+29 |   }
    |   - `s` dropped here while still borrowed
 
 error[E0505]: cannot move out of `s` because it is borrowed
-  --> src/fail_tests/move_ref_out_of_bound.rs:29:10
+  --> src/fail_tests/move_ref_not_borrowed.rs:28:10
    |
 16 |       let mut s = CopyRefBuilder {
    |           ----- binding `s` declared here
@@ -26,10 +25,9 @@ error[E0505]: cannot move out of `s` because it is borrowed
    |       - borrow of `s` occurs here
    |  _____|
    | |
-25 | |         *f.ref2 = Some(f.other);
-26 | |         *f.ref1 = *f.ref2;
-27 | |     });
+25 | |         *f.ref1 = Some(f.other);
+26 | |     });
    | |______- argument requires that `s` is borrowed for `'static`
-28 |
-29 |       drop(s);
+27 |
+28 |       drop(s);
    |            ^ move out of `s` occurs here

--- a/examples/src/fail_tests/move_ref_out_of_bound.rs
+++ b/examples/src/fail_tests/move_ref_out_of_bound.rs
@@ -1,0 +1,30 @@
+use ouroboros::self_referencing;
+
+#[self_referencing]
+struct CopyRef {
+    data: String,
+    #[borrows(data)]
+    #[covariant]
+    ref1: Option<&'this str>,
+    other: String,
+    #[borrows(data, other)]
+    #[covariant]
+    ref2: Option<&'this str>,
+}
+
+fn main() {
+    let mut s = CopyRefBuilder {
+        data: "test".to_string(),
+        ref1_builder: |_| None,
+        other: "other".to_string(),
+        ref2_builder: |x, _| Some(x),
+    }
+    .build();
+
+    s.with_mut(|f| {
+        *f.ref2 = Some(f.other);
+        *f.ref1 = *f.ref2;
+    });
+
+    drop(s);
+}

--- a/examples/src/fail_tests/move_ref_out_of_bound.stderr
+++ b/examples/src/fail_tests/move_ref_out_of_bound.stderr
@@ -1,0 +1,35 @@
+error[E0597]: `s` does not live long enough
+  --> src/main.rs:24:5
+   |
+16 |       let mut s = CopyRefBuilder {
+   |           ----- binding `s` declared here
+...
+24 |       s.with_mut(|f| {
+   |       ^ borrowed value does not live long enough
+   |  _____|
+   | |
+25 | |         *f.ref2 = Some(f.other);
+26 | |         *f.ref1 = *f.ref2;
+27 | |     });
+   | |______- argument requires that `s` is borrowed for `'static`
+...
+30 |   }
+   |   - `s` dropped here while still borrowed
+
+error[E0505]: cannot move out of `s` because it is borrowed
+  --> src/main.rs:29:10
+   |
+16 |       let mut s = CopyRefBuilder {
+   |           ----- binding `s` declared here
+...
+24 |       s.with_mut(|f| {
+   |       - borrow of `s` occurs here
+   |  _____|
+   | |
+25 | |         *f.ref2 = Some(f.other);
+26 | |         *f.ref1 = *f.ref2;
+27 | |     });
+   | |______- argument requires that `s` is borrowed for `'static`
+28 |
+29 |       drop(s);
+   |            ^ move out of `s` occurs here

--- a/ouroboros_macro/src/generate/with_mut.rs
+++ b/ouroboros_macro/src/generate/with_mut.rs
@@ -23,13 +23,17 @@ pub fn make_with_all_mut_function(
     let mut borrowed_vars: Vec<HashSet<usize>> = Vec::new();
 
     // I don't think the reverse is necessary but it does make the expanded code more uniform.
-    for field in info.fields.iter().rev() {
+    for (i, field) in info.fields.iter().enumerate().rev() {
         let field_name = &field.name;
         let field_type = &field.typ;
         let lifetime = format_ident!("this{}", lifetime_idents.len());
         if uses_this_lifetime(quote! { #field_type }) || field.field_type == FieldType::Borrowed {
             lifetime_idents.push(lifetime.clone());
-            borrowed_vars.push(field.borrows.iter().map(|b| b.index).collect());
+            let mut borrowed: HashSet<_> = field.borrows.iter().map(|b| b.index).collect();
+            if borrowed.is_empty() {
+                borrowed.insert(i);
+            }
+            borrowed_vars.push(borrowed);
         }
         let field_type = replace_this_with_lifetime(quote! { #field_type }, lifetime.clone());
         if field.field_type == FieldType::Tail {


### PR DESCRIPTION
This branch changes lifetime bounds of `BorrowedMutFields` to allow copying references. (fixes #118)

Struct definition:
```rust
#[self_referencing]
struct CopyRef {
    data: String,
    #[borrows(data)]
    #[covariant]
    ref1: Option<&'this str>,
    #[borrows(data)]
    #[covariant]
    ref2: Option<&'this str>,
    other: String,
}
```

Generated code:
```rust
pub(super) struct BorrowedMutFields<'outer_borrow, 'this2, 'this1, 'this0>
where
    'static: 'this0,
    'static: 'this1,
    'static: 'this2,
    'this2: 'this1,
    'this1: 'this2,
    'this2: 'this0,
    'this0: 'this2,
{
    pub(super) other: &'outer_borrow mut String,
    pub(super) ref2: &'outer_borrow mut Option<&'this0 str>,
    pub(super) ref1: &'outer_borrow mut Option<&'this1 str>,
    pub(super) data: &'this2 String,
}
```

Test:
```rust
let mut s = CopyRefBuilder {
    data: "test".to_string(),
    ref1_builder: |_| None,
    ref2_builder: |x| Some(x),
    other: "other".to_string(),
}.build();

s.with_mut(|f| {
    *f.ref2 = *f.ref1;
});
s.with_mut(|f| {
    *f.ref1 = *f.ref2;
});
s.with_mut(|f| {
    *f.ref1 = Some(f.data);
});
/* compile error
s.with_mut(|f| {
    *f.ref1 = Some(f.other);
});
*/
```