### PR TITLE
Add a `#[no_box]` attribute to denote that a field does not need `AliasableBox`

### DIFF
--- a/examples/src/fail_tests/auto_covariant.stderr
+++ b/examples/src/fail_tests/auto_covariant.stderr
@@ -11,7 +11,7 @@ error: Ouroboros cannot automatically determine if this type is covariant.
   --> src/fail_tests/auto_covariant.rs:11:12
    |
 11 |     field: NotGuaranteedCovariant<'this>
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0601]: `main` function not found in crate `$CRATE`
   --> src/fail_tests/auto_covariant.rs:12:2

--- a/examples/src/fail_tests/move_ref_outside_closure.stderr
+++ b/examples/src/fail_tests/move_ref_outside_closure.stderr
@@ -1,24 +1,12 @@
-error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
-  --> src/fail_tests/move_ref_outside_closure.rs:16:48
+error[E0597]: `instance` does not live long enough
+  --> src/fail_tests/move_ref_outside_closure.rs:16:5
    |
+11 |     let instance = BoxAndRefBuilder {
+   |         -------- binding `instance` declared here
+...
+15 |     let mut stored_ref: Option<&'static i32> = None;
+   |                         -------------------- type annotation requires that `instance` is borrowed for `'static`
 16 |     instance.with_data_ref(|dref| stored_ref = Some(*dref));
-   |                                                ^^^^^^^^^^^
-   |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
-  --> src/fail_tests/move_ref_outside_closure.rs:16:28
-   |
-16 |     instance.with_data_ref(|dref| stored_ref = Some(*dref));
-   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...so that reference does not outlive borrowed content
-  --> src/fail_tests/move_ref_outside_closure.rs:16:53
-   |
-16 |     instance.with_data_ref(|dref| stored_ref = Some(*dref));
-   |                                                     ^^^^^
-   = note: but, the lifetime must be valid for the static lifetime...
-note: ...so that the expression is assignable
-  --> src/fail_tests/move_ref_outside_closure.rs:16:48
-   |
-16 |     instance.with_data_ref(|dref| stored_ref = Some(*dref));
-   |                                                ^^^^^^^^^^^
-   = note: expected `Option<&'static i32>`
-              found `Option<&i32>`
+   |     ^^^^^^^^ borrowed value does not live long enough
+17 | }
+   | - `instance` dropped here while still borrowed

--- a/examples/src/fail_tests/no_box_non_aliasable.rs
+++ b/examples/src/fail_tests/no_box_non_aliasable.rs
@@ -9,9 +9,11 @@ struct Test {
 }
 
 #[self_referencing]
-struct Test {
+struct Test2 {
     #[no_box]
     data: Box<()>,
     #[borrows(data)]
     field: (),
 }
+
+fn main() {}

--- a/examples/src/fail_tests/no_box_non_aliasable.rs
+++ b/examples/src/fail_tests/no_box_non_aliasable.rs
@@ -1,0 +1,17 @@
+use ouroboros::self_referencing;
+
+#[self_referencing]
+struct Test {
+    #[no_box]
+    data: (),
+    #[borrows(data)]
+    field: (),
+}
+
+#[self_referencing]
+struct Test {
+    #[no_box]
+    data: Box<()>,
+    #[borrows(data)]
+    field: (),
+}

--- a/examples/src/fail_tests/no_box_non_aliasable.stderr
+++ b/examples/src/fail_tests/no_box_non_aliasable.stderr
@@ -1,0 +1,127 @@
+error[E0277]: the trait bound `(): Deref` is not satisfied
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `()`
+  |
+  = note: this error originates in the attribute macro `self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0614]: type `()` cannot be dereferenced
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `(): Deref` is not satisfied
+ --> src/fail_tests/no_box_non_aliasable.rs:6:5
+  |
+6 |     data: (),
+  |     ^^^^ the trait `Deref` is not implemented for `()`
+
+error[E0308]: mismatched types
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^ expected `&<() as Deref>::Target`, found `&()`
+...
+8 |     field: (),
+  |     ----- arguments to this function are incorrect
+  |
+  = note: expected reference `&<() as Deref>::Target`
+             found reference `&()`
+  = help: consider constraining the associated type `<() as Deref>::Target` to `()` or calling a method that returns `<() as Deref>::Target`
+  = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: type parameter defined here
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the attribute macro `self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^
+  | |
+  | expected `&<() as Deref>::Target`, found `&()`
+  | arguments to this function are incorrect
+  |
+  = note: expected reference `&'outer_borrow <() as Deref>::Target`
+             found reference `&()`
+  = help: consider constraining the associated type `<() as Deref>::Target` to `()` or calling a method that returns `<() as Deref>::Target`
+  = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: type parameter defined here
+ --> src/fail_tests/no_box_non_aliasable.rs:3:1
+  |
+3 | #[self_referencing]
+  | ^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the attribute macro `self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `(): aliasable_deref_trait::AliasableDeref` is not satisfied
+ --> src/fail_tests/no_box_non_aliasable.rs:5:7
+  |
+5 |     #[no_box]
+  |       ^^^^^^ the trait `aliasable_deref_trait::AliasableDeref` is not implemented for `()`
+  |
+  = help: the following other types implement trait `aliasable_deref_trait::AliasableDeref`:
+            AliasableBox<T>
+            Arc<T>
+            MutexGuard<'a, T>
+            Rc<T>
+            Ref<'a, T>
+            RefMut<'a, T>
+            RwLockReadGuard<'a, T>
+            RwLockWriteGuard<'a, T>
+          and $N others
+note: required by a bound in `AssertAliasableStableDeref`
+ --> $WORKSPACE/ouroboros/src/lib.rs
+  |
+  |     pub struct AssertAliasableStableDeref<T: AliasableDeref + StableDeref>(PhantomData<T>);
+  |                                              ^^^^^^^^^^^^^^ required by this bound in `AssertAliasableStableDeref`
+
+error[E0277]: the trait bound `(): stable_deref_trait::StableDeref` is not satisfied
+ --> src/fail_tests/no_box_non_aliasable.rs:5:7
+  |
+5 |     #[no_box]
+  |       ^^^^^^ the trait `stable_deref_trait::StableDeref` is not implemented for `()`
+  |
+  = help: the following other types implement trait `stable_deref_trait::StableDeref`:
+            &'a T
+            &'a mut T
+            AliasableBox<T>
+            Arc<T>
+            Box<T>
+            CString
+            MutexGuard<'a, T>
+            OsString
+          and $N others
+note: required by a bound in `AssertAliasableStableDeref`
+ --> $WORKSPACE/ouroboros/src/lib.rs
+  |
+  |     pub struct AssertAliasableStableDeref<T: AliasableDeref + StableDeref>(PhantomData<T>);
+  |                                                               ^^^^^^^^^^^ required by this bound in `AssertAliasableStableDeref`
+
+error[E0277]: the trait bound `Box<()>: aliasable_deref_trait::AliasableDeref` is not satisfied
+  --> src/fail_tests/no_box_non_aliasable.rs:13:7
+   |
+13 |     #[no_box]
+   |       ^^^^^^ the trait `aliasable_deref_trait::AliasableDeref` is not implemented for `Box<()>`
+   |
+   = help: the following other types implement trait `aliasable_deref_trait::AliasableDeref`:
+             AliasableBox<T>
+             Arc<T>
+             MutexGuard<'a, T>
+             Rc<T>
+             Ref<'a, T>
+             RefMut<'a, T>
+             RwLockReadGuard<'a, T>
+             RwLockWriteGuard<'a, T>
+           and $N others
+note: required by a bound in `AssertAliasableStableDeref`
+  --> $WORKSPACE/ouroboros/src/lib.rs
+   |
+   |     pub struct AssertAliasableStableDeref<T: AliasableDeref + StableDeref>(PhantomData<T>);
+   |                                              ^^^^^^^^^^^^^^ required by this bound in `AssertAliasableStableDeref`

--- a/examples/src/fail_tests/refuse_non_std_box.stderr
+++ b/examples/src/fail_tests/refuse_non_std_box.stderr
@@ -7,3 +7,11 @@ error[E0599]: no function or associated item named `is_std_box_type` found for s
    = note: the function or associated item was found for
            - `CheckIfTypeIsStd<std::boxed::Box<T>>`
    = note: this error originates in the attribute macro `self_referencing` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: unused variable: `simple`
+  --> src/fail_tests/refuse_non_std_box.rs:27:9
+   |
+27 |     let simple = Simple::new(Box::new(format!("Hello world")), |data_ref| data_ref);
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_simple`
+   |
+   = note: `#[warn(unused_variables)]` on by default

--- a/examples/src/fail_tests/swap_refs_for_use_after_free.stderr
+++ b/examples/src/fail_tests/swap_refs_for_use_after_free.stderr
@@ -1,13 +1,16 @@
 error[E0597]: `t` does not live long enough
   --> src/fail_tests/swap_refs_for_use_after_free.rs:26:5
    |
-26 | /     t.with_mut(|fields| {
+21 |       let mut t = Tricky::new(
+   |           ----- binding `t` declared here
+...
+26 |       t.with_mut(|fields| {
+   |       ^ borrowed value does not live long enough
+   |  _____|
+   | |
 27 | |         *fields.ref1 = PrintStrRef(fields.data2);
 28 | |     });
-   | |      ^
-   | |      |
-   | |______borrowed value does not live long enough
-   |        argument requires that `t` is borrowed for `'static`
+   | |______- argument requires that `t` is borrowed for `'static`
 29 |       drop(t);
 30 |   }
    |   - `t` dropped here while still borrowed
@@ -15,12 +18,15 @@ error[E0597]: `t` does not live long enough
 error[E0505]: cannot move out of `t` because it is borrowed
   --> src/fail_tests/swap_refs_for_use_after_free.rs:29:10
    |
-26 | /     t.with_mut(|fields| {
+21 |       let mut t = Tricky::new(
+   |           ----- binding `t` declared here
+...
+26 |       t.with_mut(|fields| {
+   |       - borrow of `t` occurs here
+   |  _____|
+   | |
 27 | |         *fields.ref1 = PrintStrRef(fields.data2);
 28 | |     });
-   | |      -
-   | |      |
-   | |______borrow of `t` occurs here
-   |        argument requires that `t` is borrowed for `'static`
+   | |______- argument requires that `t` is borrowed for `'static`
 29 |       drop(t);
    |            ^ move out of `t` occurs here

--- a/examples/src/fail_tests/use_after_free.stderr
+++ b/examples/src/fail_tests/use_after_free.stderr
@@ -1,8 +1,11 @@
 error[E0505]: cannot move out of `instance` because it is borrowed
   --> src/fail_tests/use_after_free.rs:16:10
    |
+11 |     let instance = BoxAndRefBuilder {
+   |         -------- binding `instance` declared here
+...
 15 |     let data_ref = instance.with_data_ref(|dref| *dref);
-   |                    ------------------------------------ borrow of `instance` occurs here
+   |                    -------- borrow of `instance` occurs here
 16 |     drop(instance);
    |          ^^^^^^^^ move out of `instance` occurs here
 17 |     println!("{:?}", data_ref);

--- a/examples/src/fail_tests/use_moved_ref_after_free.stderr
+++ b/examples/src/fail_tests/use_moved_ref_after_free.stderr
@@ -1,8 +1,11 @@
 error[E0505]: cannot move out of `instance` because it is borrowed
   --> src/fail_tests/use_moved_ref_after_free.rs:17:10
    |
+11 |     let instance = BoxAndRefBuilder {
+   |         -------- binding `instance` declared here
+...
 16 |     instance.with_data_ref(|dref| stored_ref = Some(*dref));
-   |     ------------------------------------------------------- borrow of `instance` occurs here
+   |     -------- borrow of `instance` occurs here
 17 |     drop(instance);
    |          ^^^^^^^^ move out of `instance` occurs here
 18 |     println!("{:?}", stored_ref);

--- a/examples/src/ok_tests.rs
+++ b/examples/src/ok_tests.rs
@@ -1,5 +1,6 @@
 use alloc::{borrow::ToOwned, boxed::Box};
 use core::fmt::Debug;
+use std::rc::Rc;
 
 use ouroboros::self_referencing;
 
@@ -7,7 +8,8 @@ use ouroboros::self_referencing;
 
 #[self_referencing]
 struct TraitObject {
-    data: Box<dyn Debug>,
+    #[no_box]
+    data: Rc<dyn Debug>,
     #[borrows(data)]
     dref: &'this dyn Debug,
 }
@@ -273,7 +275,7 @@ fn double_lifetime() {
 }
 
 #[cfg(not(feature = "miri"))]
-#[rustversion::stable(1.62)]
+#[rustversion::stable(1.80)]
 mod compile_tests {
     /// Tests that all files in fail_tests fail to compile.
     #[test]

--- a/ouroboros/Cargo.toml
+++ b/ouroboros/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/ouroboros"
 repository = "https://github.com/someguynamedjosh/ouroboros"
 
 [dependencies]
-aliasable = "0.1.3"
+aliasable = { version = "0.1.3", features = ["traits"] }
 ouroboros_macro = { version = "0.18.4", path = "../ouroboros_macro" }
 static_assertions = "1.1.0"
 

--- a/ouroboros_macro/src/generate/into_heads.rs
+++ b/ouroboros_macro/src/generate/into_heads.rs
@@ -23,7 +23,7 @@ pub fn make_into_heads(info: &StructInfo, options: Options) -> (TokenStream, Tok
             code.push(quote! { ::core::mem::drop(this.#field_name); });
         } else {
             code.push(quote! { let #field_name = this.#field_name; });
-            if field.is_borrowed() {
+            if field.is_stored_in_aliasable_box() {
                 field_initializers
                     .push(quote! { #field_name: ::ouroboros::macro_help::unbox(#field_name) });
             } else {

--- a/ouroboros_macro/src/generate/try_constructor.rs
+++ b/ouroboros_macro/src/generate/try_constructor.rs
@@ -107,7 +107,7 @@ pub fn create_try_builder_and_constructor(
                 field_name
             );
             if !field.self_referencing {
-                if field.is_borrowed() {
+                if field.is_stored_in_aliasable_box() {
                     head_recover_code[current_head_index] = quote! {
                         #field_name: ::ouroboros::macro_help::unbox(#field_name)
                     };
@@ -125,10 +125,7 @@ pub fn create_try_builder_and_constructor(
             // Ok so hear me out basically without this thing here my IDE thinks the rest of the
             // code is a string and it all turns green.
             {}
-            doc_table += &format!(
-                "| `{}` | Use a function or closure: `(",
-                builder_name
-            );
+            doc_table += &format!("| `{}` | Use a function or closure: `(", builder_name);
             let mut builder_args = Vec::new();
             for (index, borrow) in field.borrows.iter().enumerate() {
                 let borrowed_name = &info.fields[borrow.index].name;

--- a/ouroboros_macro/src/generate/type_asserts.rs
+++ b/ouroboros_macro/src/generate/type_asserts.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use syn::GenericParam;
 
 use crate::{
@@ -28,6 +28,12 @@ pub fn make_type_asserts(info: &StructInfo) -> TokenStream {
                 replace_this_with_lifetime(quote! { #field_type }, fake_lifetime.clone());
             checks.push(quote! {
                 ::ouroboros::macro_help::CheckIfTypeIsStd::<#static_field_type>::#checker_name();
+            });
+        }
+
+        if let Some(no_box_span) = field.no_box {
+            checks.push(quote_spanned! {no_box_span=>
+                let _: ::ouroboros::macro_help::AssertAliasableStableDeref<#field_type>;
             });
         }
     }

--- a/ouroboros_macro/src/generate/with.rs
+++ b/ouroboros_macro/src/generate/with.rs
@@ -17,7 +17,7 @@ pub fn make_with_all_function(
     // I don't think the reverse is necessary but it does make the expanded code more uniform.
     for field in info.fields.iter().rev() {
         let field_name = &field.name;
-        let field_type = &field.typ;
+        let field_type = field.ref_target_type();
         if field.field_type == FieldType::Tail {
             fields.push(quote! { #visibility #field_name: &'outer_borrow #field_type });
             field_assignments.push(quote! { #field_name: &this.#field_name });

--- a/ouroboros_macro/src/generate/with_each.rs
+++ b/ouroboros_macro/src/generate/with_each.rs
@@ -9,13 +9,16 @@ pub enum ProcessingError {
     Covariance(Vec<Diagnostic>),
 }
 
-pub fn make_with_functions(info: &StructInfo, options: Options) -> (Vec<TokenStream>, Vec<Diagnostic>) {
+pub fn make_with_functions(
+    info: &StructInfo,
+    options: Options,
+) -> (Vec<TokenStream>, Vec<Diagnostic>) {
     let mut users = Vec::new();
     let mut errors = Vec::new();
     for field in &info.fields {
         let visibility = &field.vis;
         let field_name = &field.name;
-        let field_type = &field.typ;
+        let field_type = field.ref_target_type();
         // If the field is not a tail, we need to serve up the same kind of reference that other
         // fields in the struct may have borrowed to ensure safety.
         if field.field_type == FieldType::Tail {

--- a/ouroboros_macro/src/generate/with_mut.rs
+++ b/ouroboros_macro/src/generate/with_mut.rs
@@ -21,7 +21,7 @@ pub fn make_with_all_mut_function(
     // I don't think the reverse is necessary but it does make the expanded code more uniform.
     for field in info.fields.iter().rev() {
         let field_name = &field.name;
-        let field_type = &field.typ;
+        let field_type = field.ref_target_type();
         let lifetime = format_ident!("this{}", lifetime_idents.len());
         if uses_this_lifetime(quote! { #field_type }) || field.field_type == FieldType::Borrowed {
             lifetime_idents.push(lifetime.clone());

--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -63,7 +63,7 @@ fn self_referencing_impl(
     let (with_defs, with_errors) = make_with_functions(&info, options);
     let with_errors = with_errors
         .into_iter()
-        .map(|err| err.emit_as_expr_tokens())
+        .map(|err| err.emit_as_item_tokens())
         .collect::<Vec<_>>();
     let (with_all_struct_def, with_all_fn_def) = make_with_all_function(&info, options)?;
     let (with_all_mut_struct_def, with_all_mut_fn_def) =


### PR DESCRIPTION
Closes #115.

Also move the trybuild tests to a more recent rustc version.