### PR TITLE
Prevent the user from getting a too many arguments clippy warning

### DIFF
--- a/ouroboros_macro/src/lib.rs
+++ b/ouroboros_macro/src/lib.rs
@@ -94,6 +94,7 @@ fn self_referencing_impl(
             #actual_struct_def
             #internal_struct_def
             #drop_impl
+            #[allow(clippy::too_many_arguments)] //This one makes a difference, verified
             #borrowchk_summoner
             #builder_def
             #async_builder_def
@@ -106,6 +107,7 @@ fn self_referencing_impl(
             #(#with_errors)*
             #heads_struct_def
             #impls
+            #[allow(clippy::too_many_arguments)] //This one makes a difference, verified
             impl <#generic_params> #struct_name <#(#generic_args),*> #generic_where {
                 #constructor_def
                 #async_constructor_def


### PR DESCRIPTION
If the user of this library has a lot of struct members that use this library then they can get a clippy warning about too many arguments. This check-in suppresses that warning.