### PR TITLE
macro: bump heck from 0.4.1 to 0.5

### DIFF
--- a/ouroboros_macro/Cargo.toml
+++ b/ouroboros_macro/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/someguynamedjosh/ouroboros"
 proc-macro = true
 
 [dependencies]
-heck = "0.4.1"
+heck = "0.5"
 proc-macro2 = "1.0"
 proc-macro2-diagnostics = "0.10"
 quote = "1.0"


### PR DESCRIPTION
Looks like this doesn't require code changes. Tests passed locally.
MSRV does not need to be raised, heck 0.5.0 MSRV is lower than the current MSRV of ouroboros.
